### PR TITLE
Fixed: API Level 30 Migrations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
@@ -61,27 +60,27 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-alpha07'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-alpha07'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-alpha07'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-rc01'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.0-alpha07'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.0-rc01'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.core:core-ktx:1.3.2'
     implementation "androidx.activity:activity-ktx:1.1.0"
     implementation "androidx.fragment:fragment-ktx:1.2.5"
     implementation 'androidx.viewpager2:viewpager2:1.1.0-alpha01'
 
     // webservice Setup
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.squareup.retrofit2:retrofit:2.7.1'
-    implementation 'com.squareup.okhttp3:okhttp:4.8.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.7.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.3.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.20'
     implementation 'com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0'
-    implementation "androidx.paging:paging-runtime-ktx:3.0.0-alpha05"
+    implementation 'androidx.paging:paging-runtime-ktx:3.0.0-alpha12'
 
     //Image downloading and Caching library
     implementation 'com.squareup.picasso:picasso:2.71828'
@@ -97,29 +96,29 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
 
     //Test Setup
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.8.0'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2-native-mt'
 
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.arch.core:core-testing:2.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.8.0'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
 
 
     //Tagger & Metadata Setup
-    implementation 'info.debatty:java-string-similarity:1.2.1'
+    implementation 'info.debatty:java-string-similarity:2.0.0'
     implementation 'com.github.amcap1712:KTaglib:release-SNAPSHOT'
 
     //Design Setup
-    implementation 'androidx.browser:browser:1.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha05'
+    implementation 'androidx.browser:browser:1.3.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0-beta01'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
-    implementation "com.google.android.material:material:1.3.0-alpha02"
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.google.android.material:material:1.3.0-beta01'
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation "com.airbnb.android:lottie:$lottieVersion"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,27 +60,27 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-rc01'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-rc01'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-alpha07'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-alpha07'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-alpha07'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.0-alpha07'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.core:core-ktx:1.3.1'
     implementation "androidx.activity:activity-ktx:1.1.0"
     implementation "androidx.fragment:fragment-ktx:1.2.5"
     implementation 'androidx.viewpager2:viewpager2:1.1.0-alpha01'
 
     // webservice Setup
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.7.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.8.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.7.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.3.1'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.20'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
     implementation 'com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0'
-    implementation 'androidx.paging:paging-runtime-ktx:3.0.0-alpha12'
+    implementation "androidx.paging:paging-runtime-ktx:3.0.0-alpha05"
 
     //Image downloading and Caching library
     implementation 'com.squareup.picasso:picasso:2.71828'
@@ -96,29 +96,29 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
 
     //Test Setup
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.8.0'
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2-native-mt'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
 
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.arch.core:core-testing:2.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.8.0'
 
 
     //Tagger & Metadata Setup
-    implementation 'info.debatty:java-string-similarity:2.0.0'
+    implementation 'info.debatty:java-string-similarity:1.2.1'
     implementation 'com.github.amcap1712:KTaglib:release-SNAPSHOT'
 
     //Design Setup
-    implementation 'androidx.browser:browser:1.3.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0-beta01'
+    implementation 'androidx.browser:browser:1.2.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha05'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'com.google.android.material:material:1.3.0-beta01'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    implementation "com.google.android.material:material:1.3.0-alpha02"
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation "com.airbnb.android:lottie:$lottieVersion"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/org/metabrainz/mobile/App.java
+++ b/app/src/main/java/org/metabrainz/mobile/App.java
@@ -10,9 +10,6 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.Settings;
-import android.widget.Toast;
-
-import androidx.annotation.RequiresApi;
 
 import org.metabrainz.mobile.presentation.Configuration;
 import org.metabrainz.mobile.presentation.UserPreferences;
@@ -22,7 +19,7 @@ import dagger.hilt.android.HiltAndroidApp;
 @HiltAndroidApp
 public class App extends Application {
 
-    public static final String TAGGER_ROOT_DIRECTORY = Environment.getExternalStorageDirectory() + "/Picard/";
+    public static final String TAGGER_ROOT_DIRECTORY = Environment.getRootDirectory() + "/Picard/";
     public static final String WEBSITE_BASE_URL = "https://musicbrainz.org/";
     private static App instance;
     private static Typeface robotoLight;
@@ -87,10 +84,7 @@ public class App extends Application {
         ConnectivityManager conMgr = (ConnectivityManager) getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo netInfo = conMgr.getActiveNetworkInfo();
 
-        if(netInfo == null || !netInfo.isConnected() || !netInfo.isAvailable()){
-            return false;
-        }
-        return true;
+        return netInfo != null && netInfo.isConnected() && netInfo.isAvailable();
     }
 
 }

--- a/app/src/main/java/org/metabrainz/mobile/presentation/UserPreferences.java
+++ b/app/src/main/java/org/metabrainz/mobile/presentation/UserPreferences.java
@@ -1,7 +1,7 @@
 package org.metabrainz.mobile.presentation;
 
+import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import org.metabrainz.mobile.App;
 import org.metabrainz.mobile.presentation.features.login.LoginSharedPreferences;
@@ -19,9 +19,10 @@ public class UserPreferences {
     private static final String PREFERENCE_RATINGS_TAGS = "ratings_tags";
     private static final String PREFERENCE_SYSTEM_LANGUAGE = "use_english";
     private static final String PREFERENCE_ONBOARDING = "show_onboarding";
+    private static final String SHARED_PREF_FILE = "shared_pref_file";
 
     private static SharedPreferences getPreferences() {
-        return PreferenceManager.getDefaultSharedPreferences(App.getContext());
+        return App.getContext().getSharedPreferences(SHARED_PREF_FILE, Context.MODE_PRIVATE);
     }
 
     public static void setOnBoardingCompleted() {

--- a/app/src/main/java/org/metabrainz/mobile/presentation/UserPreferences.java
+++ b/app/src/main/java/org/metabrainz/mobile/presentation/UserPreferences.java
@@ -1,7 +1,8 @@
 package org.metabrainz.mobile.presentation;
 
-import android.content.Context;
 import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
 
 import org.metabrainz.mobile.App;
 import org.metabrainz.mobile.presentation.features.login.LoginSharedPreferences;
@@ -19,10 +20,9 @@ public class UserPreferences {
     private static final String PREFERENCE_RATINGS_TAGS = "ratings_tags";
     private static final String PREFERENCE_SYSTEM_LANGUAGE = "use_english";
     private static final String PREFERENCE_ONBOARDING = "show_onboarding";
-    private static final String SHARED_PREF_FILE = "shared_pref_file";
 
     private static SharedPreferences getPreferences() {
-        return App.getContext().getSharedPreferences(SHARED_PREF_FILE, Context.MODE_PRIVATE);
+        return PreferenceManager.getDefaultSharedPreferences(App.getContext());
     }
 
     public static void setOnBoardingCompleted() {

--- a/app/src/main/java/org/metabrainz/mobile/presentation/features/login/LoginSharedPreferences.java
+++ b/app/src/main/java/org/metabrainz/mobile/presentation/features/login/LoginSharedPreferences.java
@@ -1,7 +1,7 @@
 package org.metabrainz.mobile.presentation.features.login;
 
+import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import org.metabrainz.mobile.App;
 import org.metabrainz.mobile.data.sources.api.entities.AccessToken;
@@ -14,9 +14,10 @@ public class LoginSharedPreferences {
     private static final String USERNAME = "username";
     public static final int STATUS_LOGGED_IN = 1;
     public static final int STATUS_LOGGED_OUT = 0;
+    private static final String SHARED_PREF_FILE = "shared_pref_file";
 
     public static SharedPreferences getPreferences() {
-        return PreferenceManager.getDefaultSharedPreferences(App.getContext());
+        return App.getContext().getSharedPreferences(SHARED_PREF_FILE, Context.MODE_PRIVATE);
     }
 
     public static void saveOAuthToken(AccessToken token) {

--- a/app/src/main/java/org/metabrainz/mobile/presentation/features/login/LoginSharedPreferences.java
+++ b/app/src/main/java/org/metabrainz/mobile/presentation/features/login/LoginSharedPreferences.java
@@ -1,7 +1,8 @@
 package org.metabrainz.mobile.presentation.features.login;
 
-import android.content.Context;
 import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
 
 import org.metabrainz.mobile.App;
 import org.metabrainz.mobile.data.sources.api.entities.AccessToken;
@@ -14,10 +15,9 @@ public class LoginSharedPreferences {
     private static final String USERNAME = "username";
     public static final int STATUS_LOGGED_IN = 1;
     public static final int STATUS_LOGGED_OUT = 0;
-    private static final String SHARED_PREF_FILE = "shared_pref_file";
 
     public static SharedPreferences getPreferences() {
-        return App.getContext().getSharedPreferences(SHARED_PREF_FILE, Context.MODE_PRIVATE);
+        return PreferenceManager.getDefaultSharedPreferences(App.getContext());
     }
 
     public static void saveOAuthToken(AccessToken token) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
     ext {
         kotlin_version = '1.4.21'
-        navigationVersion = '2.3.2'
+        navigationVersion = '2.3.0'
         archLifecycleVersion = '1.1.1'
         gradleVersion = '3.3.1'
         supportlibVersion = '1.1.0'
-        lottieVersion = '3.6.0'
+        lottieVersion = "3.4.0"
 
         dataBindingCompilerVersion = gradleVersion
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.4.0'
-        navigationVersion = '2.3.0'
+        kotlin_version = '1.4.21'
+        navigationVersion = '2.3.2'
         archLifecycleVersion = '1.1.1'
         gradleVersion = '3.3.1'
         supportlibVersion = '1.1.0'
-        lottieVersion = "3.4.0"
+        lottieVersion = '3.6.0'
 
         dataBindingCompilerVersion = gradleVersion
     }
@@ -16,7 +16,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0-rc01'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.28-alpha'
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
- Removed the deprecated Environment.getExternalStorageDirectory() which crashes the platform and replaced it with Environment.getRootDirectory() implementation.

- With the update, removed the permission requirements for WRITE_EXTERNAL_STORAGE since it is no longer needed.

- Removed the kotlin-android-extensions since it has now been deprecated.

- Replaced the deprecated Preference Manager implementation with the Android X implementation.

- Tested and all seems to work fine.

- Available to fix more issues and updating if need be.