### PR TITLE
Button overflow in tagger fixed

### DIFF
--- a/app/src/main/res/layout/fragment_tagger.xml
+++ b/app/src/main/res/layout/fragment_tagger.xml
@@ -96,7 +96,7 @@
                 android:textSize="18sp"
                 app:layout_constraintWidth_percent="0.5"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/AcoustID" />
+                app:layout_constraintTop_toBottomOf="@id/AcoustID"/>
 
             <ImageView
                 android:id="@+id/albumArtLocal"
@@ -540,8 +540,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignStart="@id/overwrite_tags_button"
-        android:layout_margin="20dp"
-        android:padding="10dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginBottom="20dp"
+        android:layout_marginEnd="8dp"
+        android:padding="8dp"
         android:text="@string/search_type_recording"
         android:textColor="@color/white"
         android:textSize="18sp"
@@ -566,8 +569,11 @@
         android:id="@+id/overwrite_tags_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="20dp"
-        android:padding="10dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginBottom="20dp"
+        android:padding="8dp"
         android:text="@string/tagger_file_save"
         android:textAllCaps="false"
         android:textColor="@color/white"


### PR DESCRIPTION
Small fix where I handled buttons in tagger from overflowing in devices having greater screen ratios ( mine being a 20:9 device)
<hr>

![taggerbuttonerror](https://user-images.githubusercontent.com/75999921/149706692-addcf256-ad24-4442-b376-3edfb6807015.jpg) <br>
Now it looks like this
![taggerbuttonfix](https://user-images.githubusercontent.com/75999921/149706698-decbf2e0-97f9-419d-b304-6b6830cbaf12.jpg)

