### PR TITLE
search requests fixes

### DIFF
--- a/app/src/main/java/org/metabrainz/android/presentation/features/search/SearchPagingSource.kt
+++ b/app/src/main/java/org/metabrainz/android/presentation/features/search/SearchPagingSource.kt
@@ -19,6 +19,7 @@ class SearchPagingSource(val mbEntityType: MBEntityType, val query: String) : Pa
         return try {
             val response = service.searchEntity(mbEntityType.entity, query, pageSize, offset)?.string()
             var count = LoadResult.Page.COUNT_UNDEFINED
+            val artistList = JsonParser.parseString(response).asJsonObject.get("artists").asJsonArray
             if (offset == 0) {
                 val responseObject = JsonParser.parseString(response)
                 count = responseObject.asJsonObject.get("count").asInt
@@ -26,11 +27,12 @@ class SearchPagingSource(val mbEntityType: MBEntityType, val query: String) : Pa
             val itemsAfter = if (count == LoadResult.Page.COUNT_UNDEFINED) count
             else (count - offset - pageSize).coerceAtLeast(0)
             // itemsAfter is required to be at least otherwise the current page will be not loaded
-
+            val nextKey = if (artistList.isEmpty)  null
+            else pageSize+offset
             LoadResult.Page(
                 data = ResultItemUtils.getJSONResponseAsResultItemList(response, mbEntityType),
                 prevKey = null,
-                nextKey = pageSize + offset,
+                nextKey = nextKey,
                 itemsAfter = itemsAfter
             )
         } catch (e: Exception) {


### PR DESCRIPTION
Earlier, in the SearchPagingSource , the nextKey wasn't checked earlier for empty responses. As a result, we were making too many requests unnecessarily, which caused rate limits errors. I just checked if the list of artists were null and if they were nextKey value will be checked null and we won't be making more requests.
For demonstration, an example that I tried :
earlier: https://pastebin.com/NuK5xnp7
now: https://pastebin.com/VCdLFnir

P.S.  If the list of artist is great, i.e., with each offset change, the artists' responses we are getting is not empty, we still are making many requests. That's why we still will get rate limits warnings.
