### PR TITLE
BrainzPlayer and Spotify error handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId 'org.metabrainz.android'
         minSdk 21
         targetSdk 33
-        versionCode 51
-        versionName "5.1.4"
+        versionCode 52
+        versionName "5.1.5"
 
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -99,8 +99,8 @@ dependencies {
     implementation 'androidx.paging:paging-runtime-ktx:3.1.1'
 
     //Image downloading and Caching library
-    implementation 'com.github.bumptech.glide:glide:4.13.2'
-    kapt 'com.github.bumptech.glide:compiler:4.13.2'
+    implementation 'com.github.bumptech.glide:glide:4.14.1'
+    kapt 'com.github.bumptech.glide:compiler:4.14.1'
 
     //Fragment Setup For Kotlin
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
@@ -142,15 +142,15 @@ dependencies {
     implementation "androidx.compose.ui:ui-util:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.0.0-beta02'
-    implementation 'androidx.compose.material3:material3-window-size-class:1.0.0-beta02'
+    implementation 'androidx.compose.material3:material3:1.0.0-beta03'
+    implementation 'androidx.compose.material3:material3-window-size-class:1.0.0-beta03'
     implementation "androidx.compose.animation:animation:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
     implementation 'androidx.navigation:navigation-compose:2.6.0-alpha01'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1'
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
-    implementation 'io.coil-kt:coil-compose:2.2.1'
+    implementation 'io.coil-kt:coil-compose:2.2.2'
     implementation 'com.airbnb.android:lottie-compose:5.2.0'
     implementation 'androidx.navigation:navigation-compose:2.5.2'
 
@@ -171,7 +171,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    androidTestImplementation 'app.cash.turbine:turbine:0.9.0'
+    androidTestImplementation 'app.cash.turbine:turbine:0.11.0'
 
     //ViewPager
     implementation "com.google.accompanist:accompanist-pager:0.23.0"
@@ -185,5 +185,4 @@ dependencies {
     implementation "androidx.room:room-runtime:2.4.3"
     kapt "androidx.room:room-compiler:2.4.3"
     implementation "androidx.room:room-ktx:2.4.3"
-
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:dist="http://schemas.android.com/apk/distribution"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.metabrainz.android">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <dist:module dist:instant="true" />
 

--- a/app/src/main/java/org/metabrainz/android/data/sources/api/entities/listens/AdditionalInfo.kt
+++ b/app/src/main/java/org/metabrainz/android/data/sources/api/entities/listens/AdditionalInfo.kt
@@ -15,6 +15,6 @@ data class AdditionalInfo(
     val spotify_album_artist_ids: List<String>,
     val spotify_album_id: String,
     val spotify_artist_ids: List<String>,
-    val spotify_id: String,
+    val spotify_id: String?,
     val tracknumber: Int
 )

--- a/app/src/main/java/org/metabrainz/android/presentation/features/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/metabrainz/android/presentation/features/dashboard/DashboardActivity.kt
@@ -21,7 +21,6 @@ import org.metabrainz.android.presentation.components.TopAppBar
 import org.metabrainz.android.presentation.features.brainzplayer.ui.BrainzPlayerBackDropScreen
 import org.metabrainz.android.presentation.features.onboarding.FeaturesActivity
 
-
 @AndroidEntryPoint
 class DashboardActivity : ComponentActivity() {
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext {
         kotlin_version = '1.7.10'
         navigationVersion = '2.5.2'
-        hilt_version = '2.43.2'
+        hilt_version = '2.44'
         compose_version = '1.2.1'
     }
     repositories {
@@ -11,7 +11,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         // NOTE: Do not place your application dependencies here; they belong

--- a/fastlane/metadata/android/en-US/changelogs/52.txt
+++ b/fastlane/metadata/android/en-US/changelogs/52.txt
@@ -1,0 +1,1 @@
+BrainzPlayer and Spotify Player bugs have been fixed!

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
- The listens which have a spotify id will only be attempted to play use the spotify remote connection on the app now.
- BrainzPlayer now supports proper permissions and error handling to fetch the local music files available.