### PR TITLE
Remove instant apps dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,9 +120,6 @@ dependencies {
     //Barcode Scan
     implementation 'me.dm7.barcodescanner:zbar:1.9.13'
 
-    //Share
-    implementation 'com.github.akshaaatt:Share-Android:1.0.0'
-
     //Dagger-Hilt
     implementation("com.google.dagger:hilt-android:$hilt_version")
     kapt("com.google.dagger:hilt-android-compiler:$hilt_version")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId 'org.metabrainz.android'
         minSdk 21
         targetSdk 33
-        versionCode 53
-        versionName "6.0.0"
+        versionCode 54
+        versionName "6.1.0"
 
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -122,9 +122,6 @@ dependencies {
 
     //Share
     implementation 'com.github.akshaaatt:Share-Android:1.0.0'
-
-    //Instant App
-    implementation 'com.google.android.gms:play-services-instantapps:18.0.1'
 
     //Dagger-Hilt
     implementation("com.google.dagger:hilt-android:$hilt_version")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:dist="http://schemas.android.com/apk/distribution"
     xmlns:tools="http://schemas.android.com/tools">
-
-    <dist:module dist:instant="true" />
 
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/app/src/main/java/org/metabrainz/android/presentation/features/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/metabrainz/android/presentation/features/dashboard/DashboardActivity.kt
@@ -1,18 +1,10 @@
 package org.metabrainz.android.presentation.features.dashboard
 
-import android.annotation.SuppressLint
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.annotation.RequiresApi
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.material.Scaffold
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.preference.PreferenceManager

--- a/fastlane/metadata/android/en-US/changelogs/54.txt
+++ b/fastlane/metadata/android/en-US/changelogs/54.txt
@@ -1,0 +1,1 @@
+Major UI/UX revamp has been done. The Tagger and BrainzPlayer have been removed from the app. Please have a read through our blogs for more detail.


### PR DESCRIPTION
- This does not seem to improve our app experience anyway, plus it affects our F-Droid release. Hence removing it.