### PR TITLE
HTML entities Now decoded

### DIFF
--- a/app/src/main/java/org/metabrainz/android/presentation/features/adapters/BlogAdapter.kt
+++ b/app/src/main/java/org/metabrainz/android/presentation/features/adapters/BlogAdapter.kt
@@ -28,7 +28,7 @@ class BlogAdapter(private val context: Context, private val posts: ArrayList<Pos
                 Html.fromHtml(post.title,Html.FROM_HTML_MODE_COMPACT)
             }
             else ->{
-                Html.fromHtml(post.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
+                HtmlCompat.fromHtml(post.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
             }
         }
 

--- a/app/src/main/java/org/metabrainz/android/presentation/features/adapters/BlogAdapter.kt
+++ b/app/src/main/java/org/metabrainz/android/presentation/features/adapters/BlogAdapter.kt
@@ -22,7 +22,16 @@ class BlogAdapter(private val context: Context, private val posts: ArrayList<Pos
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val post = posts[position]
-        holder.heading.text = post.title
+        holder.heading.text = when{
+
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ->{
+                Html.fromHtml(post.title,Html.FROM_HTML_MODE_COMPACT)
+            }
+            else ->{
+                Html.fromHtml(post.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
+            }
+        }
+
 
         holder.body.text = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> {


### PR DESCRIPTION

There is an issue available on the issue tracker identified by **MOBILE-82**, which status is still **Open** and the resolution is **Unresolved.**

I tried a little to solve the issue.

Here is the result of my effort.

![RESIZE_IMG_1](https://user-images.githubusercontent.com/87614560/204095067-02407dbd-d99d-471f-9cc8-fdfc5851b02c.png) | ![RESIZE_IMG_2](https://user-images.githubusercontent.com/87614560/204095082-09b38fb3-6312-46c4-bba4-e557e0d25646.png)


**Please Review my code, and if you find this can solve your problem, then please accept it.**



