### PR TITLE
Removed unnecessary backslashes from gradle-wrapper.properties file

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 28 01:14:54 IST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1.Removed unnecessary backslashes from gradle-wrapper.properties file.
2.Improved readability and consistency of the file.
3.Reduced risk of errors caused by stray backslashes.